### PR TITLE
feat(debconf26): DebConf 26 post + social share image fixes

### DIFF
--- a/.github/workflows/social-share-publish.yaml
+++ b/.github/workflows/social-share-publish.yaml
@@ -75,13 +75,11 @@ jobs:
             --config .github/social-media-config.yaml \
             --from-issue ${{ github.event.issue.number }}
 
-      - name: Mark as published and close issue
+      - name: Mark as published
         if: steps.check.outputs.already_published == 'false'
         run: |
           gh issue edit ${{ github.event.issue.number }} \
             --add-label "social: published" \
-            --repo ${{ github.repository }}
-          gh issue close ${{ github.event.issue.number }} \
             --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/content/posts/2026.06.24-debconf26/debconf26.md
+++ b/content/posts/2026.06.24-debconf26/debconf26.md
@@ -19,7 +19,7 @@ Así se llama la presentación, y la pensamos para una audiencia que vive y resp
 
 ### Por qué Rust está ganando terreno
 
-Arrancamos repasando los fallos clásicos de C/C++: invalidación de iteradores, comportamiento indefinido, falta de seguridad de hilos. Cosas con las que cualquiera que programó sistemas de bajo nivel se cruzó alguna vez. A partir de ahí mostramos cómo el borrow checker y el sistema de tipos de Rust agarran un montón de esos errores en tiempo de compilación, antes de que lleguen a producción. Y de paso repasamos cómo Rust podría haber evitado un bardo real como **Heartbleed**.
+Arrancamos repasando los fallos clásicos de C/C++: invalidación de iteradores, comportamiento indefinido, falta de seguridad de hilos. Cosas con las que cualquiera que programó sistemas de bajo nivel se cruzó alguna vez. A partir de ahí mostramos cómo el borrow checker y el sistema de tipos de Rust agarran un montón de esos errores en tiempo de compilación, antes de que lleguen a producción. Y de paso repasamos cómo Rust podría haber evitado un problema real como **Heartbleed**.
 
 ### Quién lo está usando
 

--- a/content/posts/2026.06.24-debconf26/debconf26.md
+++ b/content/posts/2026.06.24-debconf26/debconf26.md
@@ -9,7 +9,7 @@ categories = ["Eventos"]
 translationKey = "debconf26"
 +++
 
-**Nos invitaron a dar una charla en [DebConf 26](https://debconf26.debconf.org)**, la conferencia anual de la comunidad Debian. Vamos a llevar la posta de Rust en Latinoamérica a uno de los eventos más importantes del mundo open-source, así que estamos re contentos.
+**Presentaremos una charla en [DebConf 26](https://debconf26.debconf.org)**, la conferencia anual de la comunidad Debian. Vamos a llevar la posta de Rust en Latinoamérica a uno de los eventos más importantes del mundo open-source, así que estamos re contentos.
 
 <img src="/images/posts/debconf26/flyer.png" alt="Oxidar va a DebConf 26: Por qué, Quiénes y Dónde en Rust" style="width:100%; max-width:450px; margin: 20px auto; display: block;">
 

--- a/scripts/social_share/detect.py
+++ b/scripts/social_share/detect.py
@@ -21,11 +21,12 @@ from shared.detect import (  # noqa: E402
 logger = logging.getLogger("social_share")
 
 BODY_EXCERPT_MAX_CHARS = 2000
-_IMAGE_RE = re.compile(r'!\[.*?\]\((/[^)]+\.(?:jpe?g|png|gif|webp))\)', re.IGNORECASE)
+_MD_IMAGE_RE = re.compile(r'!\[.*?\]\((/[^)]+\.(?:jpe?g|png|gif|webp))\)', re.IGNORECASE)
+_HTML_IMAGE_RE = re.compile(r'<img[^>]+src=["\'](/[^"\']+\.(?:jpe?g|png|gif|webp))["\']', re.IGNORECASE)
 
 
 def _extract_first_image(body: str, base_url: str) -> str | None:
-    match = _IMAGE_RE.search(body)
+    match = _MD_IMAGE_RE.search(body) or _HTML_IMAGE_RE.search(body)
     return (base_url.rstrip("/") + match.group(1)) if match else None
 
 __all__ = [

--- a/scripts/social_share/issue_formatter.py
+++ b/scripts/social_share/issue_formatter.py
@@ -56,11 +56,12 @@ def format_issue_title(post_title: str) -> str:
     return f"{ISSUE_TITLE_PREFIX} {post_title}"
 
 
-def mark_platform_published(body: str, platform: str) -> str:
-    """Add a ✅ marker to the platform section header in the issue body."""
+def mark_platform_published(body: str, platform: str, url: str = "") -> str:
+    """Add a ✅ marker (and optional post URL) to the platform section header."""
     emoji = PLATFORM_EMOJIS.get(platform, "")
     old = f"### {emoji} {platform.capitalize()}"
-    new = f"### {emoji} {platform.capitalize()} {_PUBLISHED_MARKER}"
+    suffix = f" {_PUBLISHED_MARKER} {url}" if url else f" {_PUBLISHED_MARKER}"
+    new = f"### {emoji} {platform.capitalize()}{suffix}"
     return body.replace(old, new, 1)
 
 

--- a/scripts/social_share/main.py
+++ b/scripts/social_share/main.py
@@ -247,7 +247,7 @@ def _publish_from_issue(issue_number: int, platform_map: dict) -> list[tuple]:
             result = platform.publish(msg["text"], msg["post"])
             if result.success:
                 logger.info("Published to %s: %s", msg["platform"], result.url)
-                current_body = mark_platform_published(current_body, msg["platform"])
+                current_body = mark_platform_published(current_body, msg["platform"], result.url or "")
                 requests.patch(
                     f"{GITHUB_API}/repos/{repo}/issues/{issue_number}",
                     headers=_github_headers(),


### PR DESCRIPTION
## Summary

- Adds blog post about Oxidar's talk at DebConf 26
- Fixes social share image extraction to handle HTML `<img src="...">` tags, not just markdown `![alt](url)` syntax (the debconf26 post used an HTML img tag so no image was being attached)
- Published platform headers in GitHub issues now include the link to the published post next to the ✅ marker

## Test plan

- [ ] Verify the debconf26 post renders correctly on the site
- [ ] Approve issue #33 and confirm Bluesky/Instagram attach the flyer image
- [ ] Confirm published platform headers show the post URL after the checkmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)