### PR TITLE
fix(ci): replace retired GitHub Models with Claude CLI provider

### DIFF
--- a/.github/social-media-config.yaml
+++ b/.github/social-media-config.yaml
@@ -27,7 +27,7 @@ ai:
     - Tono: entusiasta, profesional, inclusivo y accesible
     - Usa emojis con moderación (máximo 2 por publicación, solo si aportan valor real)
     - Evita emojis decorativos o al inicio de cada línea/párrafo
-    - Incluye la URL del artículo
+    - No incluyas URLs; el enlace se agrega automáticamente
     - Menciona a Oxidar cuando sea natural
     - Invita a la comunidad a leer, comentar o participar
     - No uses hashtags inventados; usa solo los relevantes al tema
@@ -36,18 +36,17 @@ ai:
 platforms:
   twitter:
     max_chars: 280
+    # t.co rewrites every link to a fixed width, regardless of real length
+    url_cost: 23
     prompt_addendum: |
       Formato Twitter/X:
-      - Máximo 280 caracteres incluyendo la URL
       - Usa 2-4 hashtags relevantes (#Rust, #RustLang, etc.)
       - Sé conciso y directo
-      - La URL cuenta como 23 caracteres
 
   linkedin:
     max_chars: 3000
     prompt_addendum: |
       Formato LinkedIn:
-      - Máximo 3000 caracteres
       - Tono más profesional y detallado
       - Incluye un párrafo introductorio enganchador
       - Usa saltos de línea para legibilidad
@@ -58,7 +57,6 @@ platforms:
     max_chars: 300
     prompt_addendum: |
       Formato Bluesky:
-      - Máximo 300 caracteres incluyendo la URL
       - Similar a Twitter pero ligeramente más largo
       - No uses hashtags tradicionales (Bluesky no los soporta igual)
       - Sé conversacional y auténtico
@@ -67,7 +65,6 @@ platforms:
     max_chars: 4096
     prompt_addendum: |
       Formato Telegram:
-      - Máximo 4096 caracteres
       - Puedes usar formato Markdown: *negrita*, _cursiva_, `código`
       - Incluye un resumen atractivo del artículo
       - Invita a unirse a la comunidad si es relevante
@@ -75,9 +72,9 @@ platforms:
 
   instagram:
     max_chars: 2200
+    include_url: false
     prompt_addendum: |
       Formato Instagram:
-      - Máximo 2200 caracteres
       - Tono visual y evocador: describe la experiencia, no solo el contenido
       - Usa saltos de línea para separar ideas
       - Incluye entre 5 y 10 hashtags relevantes al final (#Rust, #RustLang, #Programacion, etc.)

--- a/.github/social-media-config.yaml
+++ b/.github/social-media-config.yaml
@@ -15,6 +15,8 @@ ai:
     model: "gpt-4o"
   github_models:
     model: "openai/gpt-4.1-mini"
+  claude_cli:
+    model: "sonnet"
 
   system_prompt: |
     Eres el community manager de Oxidar, la comunidad latinoamericana de Rust.

--- a/.github/workflows/auto-translate.yaml
+++ b/.github/workflows/auto-translate.yaml
@@ -95,12 +95,17 @@ jobs:
         if: steps.detect.outputs.has_posts == 'true'
         run: pip install -r scripts/auto_translate/requirements.txt
 
+      - name: Install Claude Code CLI
+        if: steps.detect.outputs.has_posts == 'true'
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Run translator
         if: steps.detect.outputs.has_posts == 'true'
         id: translate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AI_PROVIDER: ${{ secrets.AI_PROVIDER || 'github_models' }}
+          AI_PROVIDER: ${{ vars.AI_PROVIDER || 'claude_cli' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |

--- a/.github/workflows/social-share.yaml
+++ b/.github/workflows/social-share.yaml
@@ -67,12 +67,17 @@ jobs:
         if: steps.detect.outputs.has_posts == 'true'
         run: pip install -r scripts/social_share/requirements.txt
 
+      - name: Install Claude Code CLI
+        if: steps.detect.outputs.has_posts == 'true'
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Generate messages and create review issues
         if: steps.detect.outputs.has_posts == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
-          AI_PROVIDER: ${{ secrets.AI_PROVIDER || 'anthropic' }}
+          AI_PROVIDER: ${{ vars.AI_PROVIDER || 'claude_cli' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |

--- a/scripts/shared/ai/base.py
+++ b/scripts/shared/ai/base.py
@@ -9,6 +9,7 @@ _AI_REGISTRY: dict[str, tuple[str, str]] = {
     "anthropic": (".anthropic_provider", "AnthropicProvider"),
     "openai": (".openai_provider", "OpenAIProvider"),
     "github_models": (".github_models_provider", "GitHubModelsProvider"),
+    "claude_cli": (".claude_cli_provider", "ClaudeCLIProvider"),
 }
 
 

--- a/scripts/shared/ai/claude_cli_provider.py
+++ b/scripts/shared/ai/claude_cli_provider.py
@@ -1,0 +1,91 @@
+"""Claude Code CLI provider — uses a Claude subscription instead of an API key.
+
+Authenticates via CLAUDE_CODE_OAUTH_TOKEN (generate one with `claude setup-token`),
+so no ANTHROPIC_API_KEY is needed. The CLI is invoked in headless print mode with
+tools disabled: this is a plain text-in/text-out completion, not an agent session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+
+from .base import AIProvider, DEFAULT_MAX_TOKENS
+
+DEFAULT_MODEL = "sonnet"
+DEFAULT_TIMEOUT = 180
+
+
+def run_claude_cli(
+    system_prompt: str,
+    user_prompt: str,
+    model: str,
+    binary: str = "claude",
+    timeout: int = DEFAULT_TIMEOUT,
+) -> str:
+    """Invoke `claude -p` and return the assistant's text response."""
+    cmd = [
+        binary,
+        "--print",
+        "--output-format", "json",
+        "--model", model,
+        "--system-prompt", system_prompt,
+        # Pure completion: no tools, no MCP servers, no session persistence.
+        "--allowed-tools", "",
+        "--strict-mcp-config",
+    ]
+    proc = subprocess.run(
+        cmd,
+        input=user_prompt,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise ValueError(f"claude CLI failed (exit {proc.returncode}): {proc.stderr.strip()}")
+
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"claude CLI returned non-JSON output: {proc.stdout[:200]}") from e
+
+    if payload.get("is_error"):
+        raise ValueError(f"claude CLI reported an error: {payload.get('result', '')}")
+
+    text = (payload.get("result") or "").strip()
+    if not text:
+        raise ValueError("Empty response from claude CLI")
+    return text
+
+
+class ClaudeCLIProvider(AIProvider):
+    """Generate text by shelling out to the Claude Code CLI."""
+
+    def __init__(self, binary: str = "claude"):
+        self._binary = binary
+
+    @classmethod
+    def from_env(cls) -> ClaudeCLIProvider:
+        binary = os.environ.get("CLAUDE_CLI_BINARY", "claude")
+        if not shutil.which(binary):
+            raise ValueError(
+                f"claude CLI not found on PATH (looked for '{binary}'). "
+                "Install it with: npm install -g @anthropic-ai/claude-code"
+            )
+        # In CI there is no interactive login to fall back on, so demand a token
+        # up front rather than failing once per platform. Locally, defer to
+        # whatever credentials the CLI already has (keychain, `claude auth`).
+        has_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY")
+        if os.environ.get("CI") and not has_token:
+            raise ValueError(
+                "CLAUDE_CODE_OAUTH_TOKEN environment variable is required in CI "
+                "(generate one with `claude setup-token`)"
+            )
+        return cls(binary=binary)
+
+    def complete(self, system_prompt: str, user_prompt: str, max_tokens: int = DEFAULT_MAX_TOKENS) -> str:
+        # max_tokens is not exposed by the CLI; length is steered via the prompt.
+        model = os.environ.get("CLAUDE_CLI_MODEL", DEFAULT_MODEL)
+        return run_claude_cli(system_prompt, user_prompt, model, binary=self._binary)

--- a/scripts/shared/tests/test_claude_cli.py
+++ b/scripts/shared/tests/test_claude_cli.py
@@ -1,0 +1,120 @@
+"""Tests for the Claude Code CLI AI provider (shared)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ai import get_ai_provider
+from ai.claude_cli_provider import ClaudeCLIProvider, run_claude_cli
+
+
+def _completed(stdout: str, returncode: int = 0, stderr: str = ""):
+    return subprocess.CompletedProcess(args=["claude"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+@pytest.fixture
+def authed(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "test-token")
+    monkeypatch.setattr("ai.claude_cli_provider.shutil.which", lambda _: "/usr/bin/claude")
+
+
+class TestRunClaudeCli:
+    def test_returns_result_text(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _completed(json.dumps({"result": "  hola  ", "is_error": False}))
+        )
+        assert run_claude_cli("sys", "user", "sonnet") == "hola"
+
+    def test_passes_prompts_and_disables_tools(self, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["input"] = kwargs.get("input")
+            return _completed(json.dumps({"result": "ok"}))
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        run_claude_cli("SYSTEM", "USER", "sonnet")
+
+        assert captured["input"] == "USER"
+        assert "SYSTEM" in captured["cmd"]
+        assert "--print" in captured["cmd"]
+        # Tools must be off: this is a completion, not an agent session.
+        assert captured["cmd"][captured["cmd"].index("--allowed-tools") + 1] == ""
+        assert "--strict-mcp-config" in captured["cmd"]
+
+    def test_raises_on_nonzero_exit(self, monkeypatch):
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _completed("", returncode=1, stderr="boom"))
+        with pytest.raises(ValueError, match="boom"):
+            run_claude_cli("sys", "user", "sonnet")
+
+    def test_raises_on_non_json_output(self, monkeypatch):
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _completed("not json"))
+        with pytest.raises(ValueError, match="non-JSON"):
+            run_claude_cli("sys", "user", "sonnet")
+
+    def test_raises_when_cli_reports_error(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run", lambda *a, **kw: _completed(json.dumps({"is_error": True, "result": "rate limited"}))
+        )
+        with pytest.raises(ValueError, match="rate limited"):
+            run_claude_cli("sys", "user", "sonnet")
+
+    def test_raises_on_empty_result(self, monkeypatch):
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _completed(json.dumps({"result": "   "})))
+        with pytest.raises(ValueError, match="Empty response"):
+            run_claude_cli("sys", "user", "sonnet")
+
+
+class TestFromEnv:
+    def test_requires_cli_on_path(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "test-token")
+        monkeypatch.setattr("ai.claude_cli_provider.shutil.which", lambda _: None)
+        with pytest.raises(ValueError, match="claude CLI not found"):
+            ClaudeCLIProvider.from_env()
+
+    def test_requires_token_in_ci(self, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setattr("ai.claude_cli_provider.shutil.which", lambda _: "/usr/bin/claude")
+        with pytest.raises(ValueError, match="CLAUDE_CODE_OAUTH_TOKEN"):
+            ClaudeCLIProvider.from_env()
+
+    def test_allows_missing_token_outside_ci(self, monkeypatch):
+        # Local runs rely on the CLI's own stored credentials.
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setattr("ai.claude_cli_provider.shutil.which", lambda _: "/usr/bin/claude")
+        assert isinstance(ClaudeCLIProvider.from_env(), ClaudeCLIProvider)
+
+    def test_succeeds_when_authed(self, authed):
+        assert isinstance(ClaudeCLIProvider.from_env(), ClaudeCLIProvider)
+
+    def test_registered_in_factory(self, authed, monkeypatch):
+        monkeypatch.setenv("AI_PROVIDER", "claude_cli")
+        assert isinstance(get_ai_provider(), ClaudeCLIProvider)
+
+
+class TestComplete:
+    def test_complete_returns_text(self, authed, monkeypatch):
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _completed(json.dumps({"result": "texto"})))
+        assert ClaudeCLIProvider.from_env().complete("sys", "user") == "texto"
+
+    def test_model_overridable_by_env(self, authed, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _completed(json.dumps({"result": "ok"}))
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setenv("CLAUDE_CLI_MODEL", "opus")
+        ClaudeCLIProvider.from_env().complete("sys", "user")
+        assert captured["cmd"][captured["cmd"].index("--model") + 1] == "opus"

--- a/scripts/social_share/ai/anthropic_provider.py
+++ b/scripts/social_share/ai/anthropic_provider.py
@@ -22,11 +22,11 @@ class AnthropicProvider(AIProvider):
             raise ValueError("ANTHROPIC_API_KEY environment variable is required")
         return cls(client=anthropic.Anthropic(api_key=api_key))
 
-    def generate(self, post: dict, platform_name: str, config: dict) -> str:
+    def generate(self, post: dict, platform_name: str, config: dict, feedback: str = "") -> str:
         ai_config = config.get("ai", {}).get("anthropic", {})
         model = ai_config.get("model", "claude-sonnet-4-5-20250929")
         system_prompt = config.get("ai", {}).get("system_prompt", "")
-        user_prompt = build_user_prompt(post, platform_name, config)
+        user_prompt = build_user_prompt(post, platform_name, config, feedback)
 
         message = self._client.messages.create(
             model=model,

--- a/scripts/social_share/ai/base.py
+++ b/scripts/social_share/ai/base.py
@@ -14,11 +14,76 @@ _AI_REGISTRY: dict[str, tuple[str, str]] = {
 }
 
 
+URL_SEPARATOR = "\n\n"
+MIN_TEXT_BUDGET = 50
+
+
+def url_policy(post: dict, platform_name: str, config: dict) -> tuple[bool, int]:
+    """Return (append_url, chars_the_url_will_consume) for a platform.
+
+    The URL is the one component whose length is known exactly before
+    generation, so its cost is reserved here rather than left to the model to
+    count. `url_cost` overrides the real length where a platform rewrites
+    links (Twitter shortens every link to 23 chars via t.co).
+    """
+    platform_config = config.get("platforms", {}).get(platform_name, {})
+    if not platform_config.get("include_url", True):
+        return False, 0
+    url = post.get("url", "")
+    if not url:
+        return False, 0
+    cost = platform_config.get("url_cost")
+    if cost is None:
+        cost = len(url)
+    return True, cost + len(URL_SEPARATOR)
+
+
+def text_budget(post: dict, platform_name: str, config: dict) -> int:
+    """Characters available for generated prose, once the URL is reserved."""
+    platform_config = config.get("platforms", {}).get(platform_name, {})
+    max_chars = platform_config.get("max_chars", DEFAULT_MAX_CHARS)
+    _, url_cost = url_policy(post, platform_name, config)
+    return max(max_chars - url_cost, MIN_TEXT_BUDGET)
+
+
+def effective_length(text: str, post: dict, platform_name: str, config: dict) -> int:
+    """Length of `text` as the platform itself counts it.
+
+    Twitter rewrites links to a fixed width, so a raw len() overstates the
+    real cost. Must use the same cost model as `text_budget`, or messages get
+    dropped for exceeding a limit they actually fit.
+    """
+    platform_config = config.get("platforms", {}).get(platform_name, {})
+    override = platform_config.get("url_cost")
+    url = post.get("url", "")
+    if override is None or not url or url not in text:
+        return len(text)
+    return len(text) - len(url) + override
+
+
+def append_url(text: str, post: dict, platform_name: str, config: dict) -> str:
+    """Append the article URL, unless the platform opts out or it is already there."""
+    should_append, _ = url_policy(post, platform_name, config)
+    url = post.get("url", "")
+    if not should_append or url in text:
+        return text
+    return f"{text.rstrip()}{URL_SEPARATOR}{url}"
+
+
 def build_user_prompt(post: dict, platform_name: str, config: dict) -> str:
     """Build the user prompt combining post data and platform rules."""
     platform_config = config.get("platforms", {}).get(platform_name, {})
-    max_chars = platform_config.get("max_chars", DEFAULT_MAX_CHARS)
     addendum = platform_config.get("prompt_addendum", "")
+    budget = text_budget(post, platform_name, config)
+    should_append, _ = url_policy(post, platform_name, config)
+
+    if should_append:
+        url_rule = (
+            "El enlace al artículo se agrega automáticamente al final del texto. "
+            "NO incluyas ninguna URL en tu respuesta."
+        )
+    else:
+        url_rule = "NO incluyas ninguna URL en tu respuesta."
 
     return f"""Genera una publicación para {platform_name}.
 
@@ -26,13 +91,18 @@ Datos del artículo:
 - Título: {post['title']}
 - Descripción: {post['description']}
 - Tags: {', '.join(post.get('tags', []))}
-- URL: {post['url']}
 
 Extracto del contenido:
 {post['body']}
 
-Reglas de la plataforma (máximo {max_chars} caracteres):
+Reglas de la plataforma:
 {addendum}
+
+{url_rule}
+
+LÍMITE ESTRICTO: tu respuesta debe tener {budget} caracteres o menos.
+Antes de responder, contá los caracteres y acortá el texto si te pasaste.
+Es preferible un mensaje más corto que uno que exceda el límite.
 
 Responde SOLO con el texto de la publicación."""
 

--- a/scripts/social_share/ai/base.py
+++ b/scripts/social_share/ai/base.py
@@ -10,6 +10,7 @@ _AI_REGISTRY: dict[str, tuple[str, str]] = {
     "anthropic": (".anthropic_provider", "AnthropicProvider"),
     "openai": (".openai_provider", "OpenAIProvider"),
     "github_models": (".github_models_provider", "GitHubModelsProvider"),
+    "claude_cli": (".claude_cli_provider", "ClaudeCLIProvider"),
 }
 
 

--- a/scripts/social_share/ai/base.py
+++ b/scripts/social_share/ai/base.py
@@ -70,7 +70,22 @@ def append_url(text: str, post: dict, platform_name: str, config: dict) -> str:
     return f"{text.rstrip()}{URL_SEPARATOR}{url}"
 
 
-def build_user_prompt(post: dict, platform_name: str, config: dict) -> str:
+def build_length_feedback(previous_length: int, budget: int) -> str:
+    """Correction block telling the model exactly how far over it went.
+
+    A concrete measurement lands better than restating the abstract budget,
+    which the model already failed to hit once.
+    """
+    excess = previous_length - budget
+    return (
+        f"CORRECCIÓN: tu respuesta anterior tenía {previous_length} caracteres, "
+        f"{excess} más que el límite de {budget}.\n"
+        f"Escribí una versión más corta que quepa en {budget} caracteres. "
+        f"Sacá hashtags, adjetivos o una oración entera si hace falta."
+    )
+
+
+def build_user_prompt(post: dict, platform_name: str, config: dict, feedback: str = "") -> str:
     """Build the user prompt combining post data and platform rules."""
     platform_config = config.get("platforms", {}).get(platform_name, {})
     addendum = platform_config.get("prompt_addendum", "")
@@ -103,6 +118,7 @@ Reglas de la plataforma:
 LÍMITE ESTRICTO: tu respuesta debe tener {budget} caracteres o menos.
 Antes de responder, contá los caracteres y acortá el texto si te pasaste.
 Es preferible un mensaje más corto que uno que exceda el límite.
+{feedback}
 
 Responde SOLO con el texto de la publicación."""
 
@@ -111,5 +127,5 @@ class AIProvider(ABC):
     """Abstract base class for AI text generation providers."""
 
     @abstractmethod
-    def generate(self, post: dict, platform_name: str, config: dict) -> str:
+    def generate(self, post: dict, platform_name: str, config: dict, feedback: str = "") -> str:
         """Generate social media text for a post on a given platform."""

--- a/scripts/social_share/ai/claude_cli_provider.py
+++ b/scripts/social_share/ai/claude_cli_provider.py
@@ -1,0 +1,93 @@
+"""Claude Code CLI provider — uses a Claude subscription instead of an API key.
+
+Authenticates via CLAUDE_CODE_OAUTH_TOKEN (generate one with `claude setup-token`),
+so no ANTHROPIC_API_KEY is needed. The CLI is invoked in headless print mode with
+tools disabled: this is a plain text-in/text-out completion, not an agent session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+
+from .base import AIProvider, build_user_prompt
+
+DEFAULT_MODEL = "sonnet"
+DEFAULT_TIMEOUT = 180
+
+
+def run_claude_cli(
+    system_prompt: str,
+    user_prompt: str,
+    model: str,
+    binary: str = "claude",
+    timeout: int = DEFAULT_TIMEOUT,
+) -> str:
+    """Invoke `claude -p` and return the assistant's text response."""
+    cmd = [
+        binary,
+        "--print",
+        "--output-format", "json",
+        "--model", model,
+        "--system-prompt", system_prompt,
+        # Pure completion: no tools, no MCP servers, no session persistence.
+        "--allowed-tools", "",
+        "--strict-mcp-config",
+    ]
+    proc = subprocess.run(
+        cmd,
+        input=user_prompt,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise ValueError(f"claude CLI failed (exit {proc.returncode}): {proc.stderr.strip()}")
+
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"claude CLI returned non-JSON output: {proc.stdout[:200]}") from e
+
+    if payload.get("is_error"):
+        raise ValueError(f"claude CLI reported an error: {payload.get('result', '')}")
+
+    text = (payload.get("result") or "").strip()
+    if not text:
+        raise ValueError("Empty response from claude CLI")
+    return text
+
+
+class ClaudeCLIProvider(AIProvider):
+    """Generate social media text by shelling out to the Claude Code CLI."""
+
+    def __init__(self, binary: str = "claude"):
+        self._binary = binary
+
+    @classmethod
+    def from_env(cls) -> ClaudeCLIProvider:
+        binary = os.environ.get("CLAUDE_CLI_BINARY", "claude")
+        if not shutil.which(binary):
+            raise ValueError(
+                f"claude CLI not found on PATH (looked for '{binary}'). "
+                "Install it with: npm install -g @anthropic-ai/claude-code"
+            )
+        # In CI there is no interactive login to fall back on, so demand a token
+        # up front rather than failing once per platform. Locally, defer to
+        # whatever credentials the CLI already has (keychain, `claude auth`).
+        has_token = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY")
+        if os.environ.get("CI") and not has_token:
+            raise ValueError(
+                "CLAUDE_CODE_OAUTH_TOKEN environment variable is required in CI "
+                "(generate one with `claude setup-token`)"
+            )
+        return cls(binary=binary)
+
+    def generate(self, post: dict, platform_name: str, config: dict) -> str:
+        ai_config = config.get("ai", {}).get("claude_cli", {})
+        model = ai_config.get("model", DEFAULT_MODEL)
+        system_prompt = config.get("ai", {}).get("system_prompt", "")
+        user_prompt = build_user_prompt(post, platform_name, config)
+        return run_claude_cli(system_prompt, user_prompt, model, binary=self._binary)

--- a/scripts/social_share/ai/claude_cli_provider.py
+++ b/scripts/social_share/ai/claude_cli_provider.py
@@ -85,9 +85,9 @@ class ClaudeCLIProvider(AIProvider):
             )
         return cls(binary=binary)
 
-    def generate(self, post: dict, platform_name: str, config: dict) -> str:
+    def generate(self, post: dict, platform_name: str, config: dict, feedback: str = "") -> str:
         ai_config = config.get("ai", {}).get("claude_cli", {})
         model = ai_config.get("model", DEFAULT_MODEL)
         system_prompt = config.get("ai", {}).get("system_prompt", "")
-        user_prompt = build_user_prompt(post, platform_name, config)
+        user_prompt = build_user_prompt(post, platform_name, config, feedback)
         return run_claude_cli(system_prompt, user_prompt, model, binary=self._binary)

--- a/scripts/social_share/ai/github_models_provider.py
+++ b/scripts/social_share/ai/github_models_provider.py
@@ -25,11 +25,11 @@ class GitHubModelsProvider(AIProvider):
             raise ValueError("GITHUB_TOKEN environment variable is required")
         return cls(client=openai.OpenAI(base_url=GITHUB_MODELS_BASE_URL, api_key=api_key))
 
-    def generate(self, post: dict, platform_name: str, config: dict) -> str:
+    def generate(self, post: dict, platform_name: str, config: dict, feedback: str = "") -> str:
         ai_config = config.get("ai", {}).get("github_models", {})
         model = ai_config.get("model", DEFAULT_MODEL)
         system_prompt = config.get("ai", {}).get("system_prompt", "")
-        user_prompt = build_user_prompt(post, platform_name, config)
+        user_prompt = build_user_prompt(post, platform_name, config, feedback)
 
         response = self._client.chat.completions.create(
             model=model,

--- a/scripts/social_share/ai/openai_provider.py
+++ b/scripts/social_share/ai/openai_provider.py
@@ -22,11 +22,11 @@ class OpenAIProvider(AIProvider):
             raise ValueError("OPENAI_API_KEY environment variable is required")
         return cls(client=openai.OpenAI(api_key=api_key))
 
-    def generate(self, post: dict, platform_name: str, config: dict) -> str:
+    def generate(self, post: dict, platform_name: str, config: dict, feedback: str = "") -> str:
         ai_config = config.get("ai", {}).get("openai", {})
         model = ai_config.get("model", "gpt-4o")
         system_prompt = config.get("ai", {}).get("system_prompt", "")
-        user_prompt = build_user_prompt(post, platform_name, config)
+        user_prompt = build_user_prompt(post, platform_name, config, feedback)
 
         response = self._client.chat.completions.create(
             model=model,

--- a/scripts/social_share/main.py
+++ b/scripts/social_share/main.py
@@ -42,8 +42,10 @@ def _github_headers() -> dict:
 def _generate_messages(posts: list[dict], ai, config: dict, platform_names: list[str]) -> list[dict]:
     """Generate messages for each post × platform. Returns list of {post, platform, text}."""
     messages = []
+    attempts = 0
     for post in posts:
         for platform_name in platform_names:
+            attempts += 1
             try:
                 text = ai.generate(post, platform_name, config)
                 max_chars = config.get("platforms", {}).get(platform_name, {}).get("max_chars", FALLBACK_MAX_CHARS)
@@ -53,6 +55,17 @@ def _generate_messages(posts: list[dict], ai, config: dict, platform_names: list
                 messages.append({"post": post, "platform": platform_name, "text": text})
             except Exception as e:
                 logger.error("AI generation failed for %s/%s: %s", post["title"], platform_name, e)
+
+    failures = attempts - len(messages)
+    if attempts and not messages:
+        # Every call failed — almost always a dead/misconfigured AI provider.
+        # Exit non-zero so CI surfaces it instead of reporting a green no-op.
+        logger.error(
+            "All %d AI generation attempt(s) failed — check AI_PROVIDER and its credentials.", attempts
+        )
+        sys.exit(1)
+    if failures:
+        logger.warning("%d of %d AI generation attempt(s) failed", failures, attempts)
     return messages
 
 

--- a/scripts/social_share/main.py
+++ b/scripts/social_share/main.py
@@ -50,8 +50,13 @@ def _generate_messages(posts: list[dict], ai, config: dict, platform_names: list
                 text = ai.generate(post, platform_name, config)
                 max_chars = config.get("platforms", {}).get(platform_name, {}).get("max_chars", FALLBACK_MAX_CHARS)
                 if len(text) > max_chars:
-                    logger.warning("Text for %s exceeds limit (%d), truncating", platform_name, max_chars)
-                    text = text[:max_chars]
+                    # Truncating cuts the trailing URL mid-string and publishes a
+                    # dead link. Drop the message instead and let review catch it.
+                    logger.error(
+                        "Text for %s/%s is %d chars, over the %d limit — dropping message",
+                        post["title"], platform_name, len(text), max_chars,
+                    )
+                    continue
                 messages.append({"post": post, "platform": platform_name, "text": text})
             except Exception as e:
                 logger.error("AI generation failed for %s/%s: %s", post["title"], platform_name, e)

--- a/scripts/social_share/main.py
+++ b/scripts/social_share/main.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from config import load_config, get_ai_provider_name, get_base_url
 from detect import detect_new_posts
 from ai import get_ai_provider
+from ai.base import append_url, effective_length
 from platforms import get_enabled_platforms, ALL_PLATFORM_NAMES
 from issue_formatter import (
     format_issue_body,
@@ -48,13 +49,17 @@ def _generate_messages(posts: list[dict], ai, config: dict, platform_names: list
             attempts += 1
             try:
                 text = ai.generate(post, platform_name, config)
+                # The model writes to a budget that excludes the URL; the URL is
+                # appended here so it can never be mangled or counted wrong.
+                text = append_url(text, post, platform_name, config)
                 max_chars = config.get("platforms", {}).get(platform_name, {}).get("max_chars", FALLBACK_MAX_CHARS)
-                if len(text) > max_chars:
+                length = effective_length(text, post, platform_name, config)
+                if length > max_chars:
                     # Truncating cuts the trailing URL mid-string and publishes a
                     # dead link. Drop the message instead and let review catch it.
                     logger.error(
                         "Text for %s/%s is %d chars, over the %d limit — dropping message",
-                        post["title"], platform_name, len(text), max_chars,
+                        post["title"], platform_name, length, max_chars,
                     )
                     continue
                 messages.append({"post": post, "platform": platform_name, "text": text})

--- a/scripts/social_share/main.py
+++ b/scripts/social_share/main.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from config import load_config, get_ai_provider_name, get_base_url
 from detect import detect_new_posts
 from ai import get_ai_provider
-from ai.base import append_url, effective_length
+from ai.base import append_url, build_length_feedback, effective_length, text_budget
 from platforms import get_enabled_platforms, ALL_PLATFORM_NAMES
 from issue_formatter import (
     format_issue_body,
@@ -40,6 +40,40 @@ def _github_headers() -> dict:
     }
 
 
+def _generate_within_budget(post: dict, platform_name: str, ai, config: dict) -> str | None:
+    """Generate text for one platform, retrying once if it overshoots.
+
+    Models count characters imprecisely, so a first attempt can land over the
+    limit. Retry once with the measured overshoot — a concrete number lands
+    better than restating the budget it just missed. Returns None if the retry
+    also overshoots, so an over-limit message is never published.
+    """
+    max_chars = config.get("platforms", {}).get(platform_name, {}).get("max_chars", FALLBACK_MAX_CHARS)
+    budget = text_budget(post, platform_name, config)
+
+    raw = ai.generate(post, platform_name, config)
+    if len(raw) > budget:
+        logger.info(
+            "Text for %s/%s is %d chars over budget (%d/%d) — retrying",
+            post["title"], platform_name, len(raw) - budget, len(raw), budget,
+        )
+        raw = ai.generate(post, platform_name, config, feedback=build_length_feedback(len(raw), budget))
+
+    # The model writes to a budget that excludes the URL; the URL is appended
+    # here so it can never be mangled or counted wrong.
+    text = append_url(raw, post, platform_name, config)
+    length = effective_length(text, post, platform_name, config)
+    if length > max_chars:
+        # Truncating cuts the trailing URL mid-string and publishes a dead
+        # link. Drop the message instead and let review catch it.
+        logger.error(
+            "Text for %s/%s is %d chars after retry, over the %d limit — dropping message",
+            post["title"], platform_name, length, max_chars,
+        )
+        return None
+    return text
+
+
 def _generate_messages(posts: list[dict], ai, config: dict, platform_names: list[str]) -> list[dict]:
     """Generate messages for each post × platform. Returns list of {post, platform, text}."""
     messages = []
@@ -48,19 +82,8 @@ def _generate_messages(posts: list[dict], ai, config: dict, platform_names: list
         for platform_name in platform_names:
             attempts += 1
             try:
-                text = ai.generate(post, platform_name, config)
-                # The model writes to a budget that excludes the URL; the URL is
-                # appended here so it can never be mangled or counted wrong.
-                text = append_url(text, post, platform_name, config)
-                max_chars = config.get("platforms", {}).get(platform_name, {}).get("max_chars", FALLBACK_MAX_CHARS)
-                length = effective_length(text, post, platform_name, config)
-                if length > max_chars:
-                    # Truncating cuts the trailing URL mid-string and publishes a
-                    # dead link. Drop the message instead and let review catch it.
-                    logger.error(
-                        "Text for %s/%s is %d chars, over the %d limit — dropping message",
-                        post["title"], platform_name, length, max_chars,
-                    )
+                text = _generate_within_budget(post, platform_name, ai, config)
+                if text is None:
                     continue
                 messages.append({"post": post, "platform": platform_name, "text": text})
             except Exception as e:

--- a/scripts/social_share/tests/test_ai.py
+++ b/scripts/social_share/tests/test_ai.py
@@ -40,9 +40,11 @@ class TestBuildUserPrompt:
         prompt = build_user_prompt(self.post, "twitter", self.config)
         assert "Rust y WebAssembly" in prompt
 
-    def test_includes_url(self):
+    def test_omits_url(self):
+        # The URL is appended after generation, not written by the model.
         prompt = build_user_prompt(self.post, "twitter", self.config)
-        assert "https://oxidar.org/wasm/" in prompt
+        assert "https://oxidar.org/wasm/" not in prompt
+        assert "NO incluyas ninguna URL" in prompt
 
     def test_includes_tags(self):
         prompt = build_user_prompt(self.post, "twitter", self.config)
@@ -51,7 +53,8 @@ class TestBuildUserPrompt:
 
     def test_includes_platform_rules(self):
         prompt = build_user_prompt(self.post, "twitter", self.config)
-        assert "280" in prompt
+        # The stated limit is the budget left after reserving the URL, not max_chars.
+        assert str(280 - len(self.post["url"]) - 2) in prompt
         assert "Sé conciso." in prompt
 
     def test_handles_missing_platform_config(self):

--- a/scripts/social_share/tests/test_claude_cli.py
+++ b/scripts/social_share/tests/test_claude_cli.py
@@ -58,7 +58,8 @@ class TestGenerate:
         # Platform rules and post data ride in the user prompt.
         assert "Formato Twitter" in captured["input"]
         assert "Rust en DebConf 26" in captured["input"]
-        assert "280" in captured["input"]
+        # The budget shown is max_chars minus the reserved URL, not max_chars.
+        assert str(280 - len(POST["url"]) - 2) in captured["input"]
 
     def test_falls_back_to_default_model(self, authed, monkeypatch):
         captured = {}

--- a/scripts/social_share/tests/test_claude_cli.py
+++ b/scripts/social_share/tests/test_claude_cli.py
@@ -1,0 +1,91 @@
+"""Tests for the Claude Code CLI AI provider (social_share)."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ai import get_ai_provider
+from ai.claude_cli_provider import ClaudeCLIProvider
+
+
+def _completed(stdout: str, returncode: int = 0, stderr: str = ""):
+    return subprocess.CompletedProcess(args=["claude"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+POST = {
+    "title": "Rust en DebConf 26",
+    "description": "Charla de Oxidar",
+    "tags": ["rust"],
+    "url": "https://oxidar.org/post/",
+    "body": "Contenido del post.",
+}
+
+CONFIG = {
+    "ai": {"system_prompt": "Eres el community manager de Oxidar.", "claude_cli": {"model": "sonnet"}},
+    "platforms": {"twitter": {"max_chars": 280, "prompt_addendum": "Formato Twitter"}},
+}
+
+
+@pytest.fixture
+def authed(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "test-token")
+    monkeypatch.setattr("ai.claude_cli_provider.shutil.which", lambda _: "/usr/bin/claude")
+
+
+class TestGenerate:
+    def test_returns_generated_text(self, authed, monkeypatch):
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _completed(json.dumps({"result": "¡Nuevo post!"})))
+        assert ClaudeCLIProvider.from_env().generate(POST, "twitter", CONFIG) == "¡Nuevo post!"
+
+    def test_uses_system_prompt_and_platform_rules(self, authed, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["input"] = kwargs.get("input")
+            return _completed(json.dumps({"result": "ok"}))
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ClaudeCLIProvider.from_env().generate(POST, "twitter", CONFIG)
+
+        assert "Eres el community manager de Oxidar." in captured["cmd"]
+        assert captured["cmd"][captured["cmd"].index("--model") + 1] == "sonnet"
+        # Platform rules and post data ride in the user prompt.
+        assert "Formato Twitter" in captured["input"]
+        assert "Rust en DebConf 26" in captured["input"]
+        assert "280" in captured["input"]
+
+    def test_falls_back_to_default_model(self, authed, monkeypatch):
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _completed(json.dumps({"result": "ok"}))
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        ClaudeCLIProvider.from_env().generate(POST, "twitter", {"platforms": {}})
+        assert captured["cmd"][captured["cmd"].index("--model") + 1] == "sonnet"
+
+    def test_propagates_cli_failure(self, authed, monkeypatch):
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _completed("", returncode=1, stderr="auth expired"))
+        with pytest.raises(ValueError, match="auth expired"):
+            ClaudeCLIProvider.from_env().generate(POST, "twitter", CONFIG)
+
+
+class TestFromEnv:
+    def test_requires_token_in_ci(self, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setattr("ai.claude_cli_provider.shutil.which", lambda _: "/usr/bin/claude")
+        with pytest.raises(ValueError, match="CLAUDE_CODE_OAUTH_TOKEN"):
+            ClaudeCLIProvider.from_env()
+
+    def test_registered_in_factory(self, authed, monkeypatch):
+        monkeypatch.setenv("AI_PROVIDER", "claude_cli")
+        assert isinstance(get_ai_provider(), ClaudeCLIProvider)

--- a/scripts/social_share/tests/test_generate.py
+++ b/scripts/social_share/tests/test_generate.py
@@ -10,7 +10,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from main import _generate_messages
 
 POST = {"title": "Rust en DebConf 26", "url": "https://oxidar.org/post/"}
-CONFIG = {"platforms": {"bluesky": {"max_chars": 50}, "telegram": {"max_chars": 4096}}}
+# include_url is off here so these cases exercise the length rules in isolation;
+# URL reservation has its own suite in test_url_budget.py.
+CONFIG = {
+    "platforms": {
+        "bluesky": {"max_chars": 50, "include_url": False},
+        "telegram": {"max_chars": 4096, "include_url": False},
+    }
+}
 
 
 class FakeAI:

--- a/scripts/social_share/tests/test_generate.py
+++ b/scripts/social_share/tests/test_generate.py
@@ -1,0 +1,70 @@
+"""Tests for message generation, length limits, and failure handling."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from main import _generate_messages
+
+POST = {"title": "Rust en DebConf 26", "url": "https://oxidar.org/post/"}
+CONFIG = {"platforms": {"bluesky": {"max_chars": 50}, "telegram": {"max_chars": 4096}}}
+
+
+class FakeAI:
+    """Returns canned text per platform, or raises if the value is an Exception."""
+
+    def __init__(self, by_platform: dict):
+        self._by_platform = by_platform
+
+    def generate(self, post, platform_name, config):
+        value = self._by_platform[platform_name]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+class TestLengthLimit:
+    def test_keeps_message_within_limit(self):
+        ai = FakeAI({"bluesky": "corto", "telegram": "largo pero permitido"})
+        messages = _generate_messages([POST], ai, CONFIG, ["bluesky", "telegram"])
+        assert [m["text"] for m in messages] == ["corto", "largo pero permitido"]
+
+    def test_drops_over_limit_message_instead_of_truncating(self):
+        # Truncation used to cut the trailing URL mid-string, publishing a dead link.
+        long_text = "x" * 40 + " https://oxidar.org/why-who-where-rust-debconf26/"
+        ai = FakeAI({"bluesky": long_text, "telegram": "ok"})
+        messages = _generate_messages([POST], ai, CONFIG, ["bluesky", "telegram"])
+
+        assert [m["platform"] for m in messages] == ["telegram"]
+        assert all(m["text"] != long_text[:50] for m in messages)
+
+    def test_message_exactly_at_limit_is_kept(self):
+        ai = FakeAI({"bluesky": "y" * 50})
+        messages = _generate_messages([POST], ai, CONFIG, ["bluesky"])
+        assert len(messages) == 1
+
+
+class TestFailureHandling:
+    def test_partial_failure_returns_remaining_messages(self):
+        ai = FakeAI({"bluesky": RuntimeError("410 Gone"), "telegram": "ok"})
+        messages = _generate_messages([POST], ai, CONFIG, ["bluesky", "telegram"])
+        assert [m["platform"] for m in messages] == ["telegram"]
+
+    def test_exits_nonzero_when_every_attempt_fails(self):
+        # A retired or misconfigured provider must fail the job, not pass as a no-op.
+        ai = FakeAI({"bluesky": RuntimeError("410 Gone"), "telegram": RuntimeError("410 Gone")})
+        with pytest.raises(SystemExit) as exc:
+            _generate_messages([POST], ai, CONFIG, ["bluesky", "telegram"])
+        assert exc.value.code == 1
+
+    def test_exits_nonzero_when_all_messages_dropped_for_length(self):
+        ai = FakeAI({"bluesky": "z" * 500})
+        with pytest.raises(SystemExit) as exc:
+            _generate_messages([POST], ai, CONFIG, ["bluesky"])
+        assert exc.value.code == 1
+
+    def test_no_posts_does_not_exit(self):
+        assert _generate_messages([], FakeAI({}), CONFIG, ["bluesky"]) == []

--- a/scripts/social_share/tests/test_generate.py
+++ b/scripts/social_share/tests/test_generate.py
@@ -21,13 +21,20 @@ CONFIG = {
 
 
 class FakeAI:
-    """Returns canned text per platform, or raises if the value is an Exception."""
+    """Returns canned text per platform, or raises if the value is an Exception.
+
+    A list value yields one entry per call, so retries can return something
+    different from the first attempt.
+    """
 
     def __init__(self, by_platform: dict):
-        self._by_platform = by_platform
+        self._by_platform = {k: list(v) if isinstance(v, list) else [v] for k, v in by_platform.items()}
+        self.calls: list[tuple[str, str]] = []
 
-    def generate(self, post, platform_name, config):
-        value = self._by_platform[platform_name]
+    def generate(self, post, platform_name, config, feedback=""):
+        self.calls.append((platform_name, feedback))
+        queue = self._by_platform[platform_name]
+        value = queue.pop(0) if len(queue) > 1 else queue[0]
         if isinstance(value, Exception):
             raise value
         return value
@@ -52,6 +59,43 @@ class TestLengthLimit:
         ai = FakeAI({"bluesky": "y" * 50})
         messages = _generate_messages([POST], ai, CONFIG, ["bluesky"])
         assert len(messages) == 1
+
+
+class TestRetryOnOvershoot:
+    def test_does_not_retry_when_first_attempt_fits(self):
+        ai = FakeAI({"bluesky": "corto"})
+        _generate_messages([POST], ai, CONFIG, ["bluesky"])
+        assert len(ai.calls) == 1
+        assert ai.calls[0][1] == ""  # no feedback on a first attempt
+
+    def test_retries_once_when_over_budget(self):
+        ai = FakeAI({"bluesky": ["x" * 80, "corto"]})
+        messages = _generate_messages([POST], ai, CONFIG, ["bluesky"])
+        assert len(ai.calls) == 2
+        assert [m["text"] for m in messages] == ["corto"]
+
+    def test_retry_feedback_states_measured_overshoot(self):
+        ai = FakeAI({"bluesky": ["x" * 80, "corto"]})
+        _generate_messages([POST], ai, CONFIG, ["bluesky"])
+
+        feedback = ai.calls[1][1]
+        assert "80" in feedback  # what it actually wrote
+        assert "50" in feedback  # the budget
+        assert "30" in feedback  # how far over
+
+    def test_drops_when_retry_also_overshoots(self):
+        # telegram succeeds so this exercises the drop, not the all-failed exit.
+        ai = FakeAI({"bluesky": ["x" * 80, "y" * 70], "telegram": "ok"})
+        messages = _generate_messages([POST], ai, CONFIG, ["bluesky", "telegram"])
+
+        bluesky_calls = [c for c in ai.calls if c[0] == "bluesky"]
+        assert len(bluesky_calls) == 2  # retried exactly once, no loop
+        assert [m["platform"] for m in messages] == ["telegram"]
+
+    def test_retry_failure_propagates_as_generation_failure(self):
+        ai = FakeAI({"bluesky": ["x" * 80, RuntimeError("boom")], "telegram": "ok"})
+        messages = _generate_messages([POST], ai, CONFIG, ["bluesky", "telegram"])
+        assert [m["platform"] for m in messages] == ["telegram"]
 
 
 class TestFailureHandling:

--- a/scripts/social_share/tests/test_url_budget.py
+++ b/scripts/social_share/tests/test_url_budget.py
@@ -1,0 +1,113 @@
+"""Tests for reserving the article URL's length ahead of generation."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ai.base import append_url, build_user_prompt, effective_length, text_budget, url_policy
+
+URL = "https://oxidar.org/why-who-where-rust-debconf26/"
+POST = {
+    "title": "Rust en DebConf 26",
+    "description": "Charla de Oxidar",
+    "tags": ["rust"],
+    "url": URL,
+    "body": "Contenido.",
+}
+
+CONFIG = {
+    "platforms": {
+        "bluesky": {"max_chars": 300},
+        "twitter": {"max_chars": 280, "url_cost": 23},
+        "instagram": {"max_chars": 2200, "include_url": False},
+    }
+}
+
+
+class TestUrlPolicy:
+    def test_defaults_to_real_url_length(self):
+        should_append, cost = url_policy(POST, "bluesky", CONFIG)
+        assert should_append
+        assert cost == len(URL) + 2  # + separator
+
+    def test_url_cost_override_wins(self):
+        # Twitter rewrites links to a fixed width via t.co.
+        _, cost = url_policy(POST, "twitter", CONFIG)
+        assert cost == 23 + 2
+
+    def test_platform_can_opt_out(self):
+        assert url_policy(POST, "instagram", CONFIG) == (False, 0)
+
+    def test_post_without_url_opts_out(self):
+        assert url_policy({"url": ""}, "bluesky", CONFIG) == (False, 0)
+
+
+class TestTextBudget:
+    def test_budget_excludes_url(self):
+        assert text_budget(POST, "bluesky", CONFIG) == 300 - len(URL) - 2
+
+    def test_budget_uses_override_cost(self):
+        assert text_budget(POST, "twitter", CONFIG) == 280 - 23 - 2
+
+    def test_opt_out_platform_keeps_full_budget(self):
+        assert text_budget(POST, "instagram", CONFIG) == 2200
+
+    def test_budget_never_goes_negative(self):
+        tiny = {"platforms": {"bluesky": {"max_chars": 10}}}
+        assert text_budget(POST, "bluesky", tiny) > 0
+
+
+class TestAppendUrl:
+    def test_appends_url(self):
+        assert append_url("Mirá esto", POST, "bluesky", CONFIG) == f"Mirá esto\n\n{URL}"
+
+    def test_does_not_double_append(self):
+        text = f"Mirá esto {URL}"
+        assert append_url(text, POST, "bluesky", CONFIG) == text
+
+    def test_skips_opt_out_platform(self):
+        assert append_url("Mirá esto", POST, "instagram", CONFIG) == "Mirá esto"
+
+    def test_result_fits_within_max_chars(self):
+        # The whole point: prose at budget + URL must still fit the real limit.
+        budget = text_budget(POST, "bluesky", CONFIG)
+        result = append_url("x" * budget, POST, "bluesky", CONFIG)
+        assert len(result) <= CONFIG["platforms"]["bluesky"]["max_chars"]
+
+
+class TestEffectiveLength:
+    def test_counts_raw_length_without_override(self):
+        text = f"hola{URL}"
+        assert effective_length(text, POST, "bluesky", CONFIG) == len(text)
+
+    def test_substitutes_url_cost_when_platform_rewrites_links(self):
+        # Twitter counts every link as 23 chars regardless of real length.
+        text = f"hola {URL}"
+        assert effective_length(text, POST, "twitter", CONFIG) == len("hola ") + 23
+
+    def test_ignores_override_when_url_absent(self):
+        assert effective_length("hola", POST, "twitter", CONFIG) == 4
+
+    def test_budget_and_length_agree(self):
+        # A message written exactly to budget must never be judged over the limit.
+        for platform in ("bluesky", "twitter", "instagram"):
+            budget = text_budget(POST, platform, CONFIG)
+            text = append_url("x" * budget, POST, platform, CONFIG)
+            max_chars = CONFIG["platforms"][platform]["max_chars"]
+            assert effective_length(text, POST, platform, CONFIG) <= max_chars, platform
+
+
+class TestPrompt:
+    def test_prompt_states_budget_not_raw_limit(self):
+        prompt = build_user_prompt(POST, "bluesky", CONFIG)
+        assert str(text_budget(POST, "bluesky", CONFIG)) in prompt
+        assert "máximo 300 caracteres" not in prompt
+
+    def test_prompt_forbids_urls(self):
+        assert "NO incluyas ninguna URL" in build_user_prompt(POST, "bluesky", CONFIG)
+        assert "NO incluyas ninguna URL" in build_user_prompt(POST, "instagram", CONFIG)
+
+    def test_prompt_omits_url_from_post_data(self):
+        # Leaving the URL in the data invites the model to echo it back.
+        assert URL not in build_user_prompt(POST, "bluesky", CONFIG)


### PR DESCRIPTION
## Problem

GitHub Models is being retired and returns `410 models_retirement_brownout`. The social-share run for the DebConf 26 post ([run 30705037495](https://github.com/oxidar-org/web/actions/runs/30705037495)) detected the post correctly, then failed all five AI calls and created no review issue — while still reporting success, because per-platform errors were only logged.

`auto-translate.yaml` uses the same provider and was about to break identically.

## Changes

**Provider**

- **`claude_cli` provider** in both AI trees (`scripts/shared/ai/`, `scripts/social_share/ai/`). Shells out to `claude -p --output-format json`, authenticating with a Claude subscription via `CLAUDE_CODE_OAUTH_TOKEN` — no API key. Runs with `--allowed-tools ""` and `--strict-mcp-config` so it stays a plain completion, not an agent session.
- **Both workflows** install the CLI and default to `claude_cli`.
- **Provider selector moved to `vars.AI_PROVIDER`.** The old `AI_PROVIDER` *secret* pinned `github_models` and would have silently overridden the new default. It has been deleted, and reading from `vars` also unmasks the provider name in logs.
- **Fail loudly.** `_generate_messages` exits non-zero when every attempt fails, so a dead provider surfaces instead of passing as a green no-op.

**Length handling**

Previously the URL was handed to the model as data and embedded by it, so the model had to count its own prose plus a 47-character link against the platform limit. It missed, and blind truncation then cut the URL mid-string (`https://oxidar.org/why-who-where-rust-debconf2`) — a dead link on Bluesky, one of the two enabled platforms.

- The URL is now **reserved deterministically**: the prompt states a budget of `max_chars` minus the URL cost and forbids URLs in the response; `append_url()` adds the link afterwards. It can no longer be mangled or miscounted.
- **URL cost is per-platform**, because platforms count links differently — Twitter rewrites every link to 23 chars via t.co (`url_cost: 23`), Bluesky/Telegram/LinkedIn count the real length, Instagram takes no URL at all (`include_url: false`, link in bio).
- `effective_length()` validates using that same cost model, so a message written to budget is never judged over the limit.
- Over-limit messages are **dropped, not truncated**.

## Required setup

`CLAUDE_CODE_OAUTH_TOKEN` secret is set; stale `AI_PROVIDER` secret removed. No further config needed.

## Verification

Generated all five platform messages for the DebConf 26 post locally through the new provider, with no API key. URLs intact on every platform that takes one; Instagram correctly omits it.

Stated budget vs. actual, across two runs after the prompt change: **5/5 and 4/5 messages within limits**, the single miss being 2 chars over. Before the change it was 38 chars over.

| Suite | Result |
|---|---|
| `shared/tests` | 35 passed |
| `auto_translate/tests` | 40 passed |
| `social_share/tests` | 88 passed, 1 failed |

The single failure is `test_linkedin_non_json_on_success`, **pre-existing on `main`** — confirmed by stashing these changes. Untouched here.

Note: running the three suites together still collides on the duplicate `tests` package name; they must be run per-directory.

## Retry on overshoot

Models count characters imprecisely, and Twitter has the tightest prose budget of any platform (280 − 23 for t.co − 2 = 255). It fit once in four generations; the rest were dropped, so enabling `TWITTER_ENABLED` would mostly have produced silence.

Over-budget messages now trigger **one** retry that feeds back the measured numbers — what it wrote, the limit, and the difference — rather than restating the budget it just missed. If the retry is still over, the message is dropped as before, so nothing over-limit is ever published.

Measured across three dry runs after this change: **5/5 messages every run**, with the retry rescuing Twitter twice (272→225 and 281→245 chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

